### PR TITLE
Fix scraper output path for level data

### DIFF
--- a/banditgui/utils/get_data.py
+++ b/banditgui/utils/get_data.py
@@ -25,7 +25,7 @@ from bs4 import BeautifulSoup
 # Constants
 BASE_URL = "https://overthewire.org/wargames/bandit/"
 LEVELS_RANGE = range(0, 35)  # bandit0 to bandit34
-OUTPUT_DIR = Path(__file__).parent.parent / "levels_data"
+OUTPUT_DIR = Path(__file__).parent.parent / "data"
 GENERAL_OUTPUT_FILE = OUTPUT_DIR / "general_info.json"
 LEVELS_OUTPUT_FILE = OUTPUT_DIR / "levels_info.json"
 ALL_DATA_FILE = OUTPUT_DIR / "all_data.json"


### PR DESCRIPTION
The `get_data.py` script was saving its scraped level information to `banditgui/levels_data/`, while the application was loading it from `banditgui/data/`.

This commit updates the `OUTPUT_DIR` in `get_data.py` to point to `banditgui/data/`. This ensures that when the scraper is run, the application uses the most current level information fetched from the OverTheWire website.

The scraper script was also run to populate the data directory with the latest information.

## Summary by Sourcery

Fix the scraper output path to align with the application’s data loading location and refresh the level data

Bug Fixes:
- Correct the scraper's OUTPUT_DIR to point to the application's data directory

Chores:
- Regenerate the level data in the data directory with the latest scraped information