### PR TITLE
feat: Add new ignore patterns to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -180,3 +180,6 @@ node_modules
 /.vscode
 /.sourcetrail
 /.mcp-servers
+/.snapshots
+TODO.md
+/.history


### PR DESCRIPTION
Adds new entries to the `.gitignore` file to exclude:
- `.snapshots` directories, likely for backup or versioning tools.
- `TODO.md` files, which are typically temporary or personal notes.
- `.history` directories, often used by IDEs or tools for file history.

## Summary by Sourcery

Ignore new files and directories by adding .snapshots, TODO.md, and .history patterns to .gitignore

Chores:
- Add .snapshots directories to .gitignore
- Add TODO.md files to .gitignore
- Add .history directories to .gitignore