### PR TITLE
Refactor: Remove OpenAI and update LLM defaults

### DIFF
--- a/banditgui/app.py
+++ b/banditgui/app.py
@@ -30,12 +30,6 @@ app = Flask(__name__)
 
 # --- Predefined LLM Models by Provider ---
 PREDEFINED_MODELS = {
-    "openai": [
-        "gpt-3.5-turbo",
-        "gpt-4",
-        "gpt-4-turbo-preview",
-        "gpt-4o"
-    ],
     "gemini": [ # Google AI Studio models
         "gemini-pro",
         "gemini-1.0-pro",
@@ -326,12 +320,7 @@ def ask_a_pro():
     litellm_model_string = model_name # Default to model_name
     litellm_kwargs = {}
 
-    if provider == "openai":
-        api_key = config.openai_api_key
-        if not api_key or api_key == "YOUR_OPENAI_API_KEY_HERE":
-            logger.error("OpenAI API key not configured.")
-            return jsonify({'status': 'error', 'message': 'OpenAI API key not configured by the administrator.'}), 503
-    elif provider == "gemini":
+    if provider == "gemini":
         api_key = config.gemini_api_key
         # Gemini model names via LiteLLM are often just the model name like "gemini-pro"
         # but sometimes "gemini/gemini-pro". For user input `model_name` should be direct.
@@ -410,8 +399,6 @@ def ask_a_pro():
     # Set environment variables for providers that might primarily rely on them,
     # though litellm.completion parameters usually take precedence.
     # This is more of a fallback or for complex litellm routing/proxy setups.
-    if config.openai_api_key and config.openai_api_key != "YOUR_OPENAI_API_KEY_HERE":
-        os.environ["OPENAI_API_KEY"] = config.openai_api_key
     if config.gemini_api_key and config.gemini_api_key != "YOUR_GEMINI_API_KEY_HERE":
         os.environ["GEMINI_API_KEY"] = config.gemini_api_key # Or GOOGLE_API_KEY depending on litellm version/usage
     if config.openrouter_api_key and config.openrouter_api_key != "YOUR_OPENROUTER_API_KEY_HERE":

--- a/banditgui/config/settings.py
+++ b/banditgui/config/settings.py
@@ -24,13 +24,12 @@ class Config:
         self.ssh_password = os.getenv('SSH_PASSWORD', 'bandit0')
 
         # LLM API Keys and Settings
-        self.openai_api_key: Optional[str] = os.getenv("OPENAI_API_KEY")
         self.gemini_api_key: Optional[str] = os.getenv("GEMINI_API_KEY")
         self.openrouter_api_key: Optional[str] = os.getenv("OPENROUTER_API_KEY")
         self.ollama_base_url: Optional[str] = os.getenv("OLLAMA_BASE_URL", "http://localhost:11434")
 
-        self.preferred_llm_provider: str = os.getenv("PREFERRED_LLM_PROVIDER", "openai")
-        self.preferred_llm_model: str = os.getenv("PREFERRED_LLM_MODEL", "gpt-3.5-turbo")
+        self.preferred_llm_provider: str = os.getenv("PREFERRED_LLM_PROVIDER", "gemini")
+        self.preferred_llm_model: str = os.getenv("PREFERRED_LLM_MODEL", "gemini-1.5-flash-latest")
 
         # Flask settings
         self.debug = os.getenv('DEBUG', 'True').lower() in ('true', '1', 't')

--- a/banditgui/static/js/bandit-app.js
+++ b/banditgui/static/js/bandit-app.js
@@ -169,11 +169,14 @@ class BanditApp {
                     this.llmProviderSelect.appendChild(option);
                 });
 
-                // TODO: Set default provider based on config if available from backend, or first one
-                // For now, just trigger model population for the first provider (if any)
-                if (Object.keys(this.predefinedModels).length > 0) {
-                    this.llmProviderSelect.value = Object.keys(this.predefinedModels)[0]; // Select first provider
-                    this.populateLlmModelDropdown(); // Populate models for the initially selected provider
+                // Set default provider to "gemini" and populate its models
+                if (this.predefinedModels["gemini"]) {
+                    this.llmProviderSelect.value = "gemini";
+                    this.populateLlmModelDropdown(); // Populate models for "gemini"
+                } else if (Object.keys(this.predefinedModels).length > 0) {
+                    // Fallback to the first provider if "gemini" is not available
+                    this.llmProviderSelect.value = Object.keys(this.predefinedModels)[0];
+                    this.populateLlmModelDropdown();
                 }
             } else {
                 console.error('Failed to fetch LLM models list:', data.message);
@@ -206,9 +209,13 @@ class BanditApp {
             option.textContent = modelName;
             this.llmModelSelect.appendChild(option);
         });
-        // TODO: Set default model if preferred_llm_model matches for this provider
+
         if (models.length > 0) {
-            this.llmModelSelect.value = models[0]; // Select first model by default
+            if (selectedProvider === "gemini" && models.includes("gemini-1.5-flash-latest")) {
+                this.llmModelSelect.value = "gemini-1.5-flash-latest";
+            } else {
+                this.llmModelSelect.value = models[0]; // Select first model by default
+            }
         }
     }
 


### PR DESCRIPTION
I've removed OpenAI from the list of available LLM providers for you. I also updated the default LLM provider to Gemini and the default model to gemini-1.5-flash-latest.

Specific changes:
- I modified `PREDEFINED_MODELS` in `app.py` to exclude OpenAI.
- I removed OpenAI API key handling from `app.py` and `config/settings.py`.
- I updated `preferred_llm_provider` and `preferred_llm_model` in `config/settings.py`.
- I adjusted `static/js/bandit-app.js` to correctly initialize and update LLM provider and model selections, ensuring "gemini" and "gemini-1.5-flash-latest" are the defaults.
- I verified `templates/index.html` requires no direct changes as dropdowns are populated dynamically.

## Summary by Sourcery

Remove OpenAI as an available LLM provider and switch defaults to Gemini and its latest flash model across the backend and frontend.

Enhancements:
- Drop OpenAI from predefined models, configuration settings, and API key handling.
- Update default LLM provider to Gemini and default model to gemini-1.5-flash-latest in settings.
- Refactor backend routing logic to only handle Gemini and remove OpenAI-specific environment setup.
- Adjust frontend JavaScript to default the provider and model dropdowns to Gemini and gemini-1.5-flash-latest.