### PR TITLE
feat: Add 'Ask-a-Pro' LLM mentor feature

### DIFF
--- a/banditgui/app.py
+++ b/banditgui/app.py
@@ -177,7 +177,7 @@ Goal: Help them understand their current situation. Provide some technical expla
 📍 Level Name: {level_name}
 🧩 Level Description: {level_description}
 📜 Command History:
-{command_history_str if command_history_str else "No commands executed yet."}
+{command_history_str or "No commands executed yet."}
 
 ---
 

--- a/banditgui/config/llm_model.json
+++ b/banditgui/config/llm_model.json
@@ -1,0 +1,17 @@
+{
+  "openai": ["gpt-4o", "gpt-4-turbo", "gpt-3.5-turbo"],
+  "gemini": ["gemini-1.5-pro", "gemini-1.5-flash"],
+  "openrouter": ["nous-hermes-2", "mistral-7b-instruct", "claude-3-opus"],
+  "anthropic": ["claude-3-opus", "claude-3-sonnet", "claude-3-haiku"],
+  "mistral": ["mistral-small", "mistral-medium", "mistral-large"],
+  "perplexity": ["pplx-7b-online", "pplx-70b-chat"],
+  "cohere": ["command-r-plus"],
+  "deepseek": ["deepseek-coder", "deepseek-llm"],
+  "groq": ["llama3-70b", "mixtral-8x7b"],
+  "ollama": [
+    "qwen2.5-1.5b",
+    "gemma3:1b",
+    "DeepSeek-R1-Distill-Llama-8B-Q4_K_M:latest",
+    "llama3.2:1b-instruct-q4_K_M"
+  ]
+}

--- a/banditgui/static/bandit-terminal.css
+++ b/banditgui/static/bandit-terminal.css
@@ -151,6 +151,33 @@ background-color: color-mix(in srgb, var(--accent-secondary) 10%, transparent);
     letter-spacing: 0.5px;
 }
 
+.mentor-message {
+    background-color: #e9ecef; /* Light gray background */
+    border-left: 4px solid #4CAF50; /* Green accent bar */
+    padding: 15px; /* Consistent padding */
+    margin-bottom: 20px; /* Consistent margin */
+    border-radius: 0 6px 6px 0; /* Consistent radius */
+    box-shadow: var(--shadow-sm);
+    color: #333; /* Darker text for better contrast on light background */
+}
+
+.mentor-message .mentor-label {
+    font-weight: bold;
+    color: #4CAF50; /* Green label text */
+    margin-bottom: 8px; /* Consistent margin */
+    letter-spacing: 0.5px; /* Consistent spacing */
+}
+
+.mentor-message .mentor-label .fas { /* Style for Font Awesome icon */
+    margin-right: 8px;
+}
+
+.mentor-message .message-content {
+    /* Add specific styles if needed, otherwise inherits from .mentor-message */
+    /* Ensuring text color is explicitly set for content if needed */
+    color: #333; 
+}
+
 #chat-input-container {
     display: flex;
     padding: 15px;

--- a/banditgui/static/js/bandit-app.js
+++ b/banditgui/static/js/bandit-app.js
@@ -539,8 +539,10 @@ Type <code>level</code> in this chat to see the current level instructions.
         // Using Font Awesome icon
         messageElement.innerHTML = `
             <div class="mentor-label"><i class="fas fa-user-graduate"></i> Mentor:</div>
-            <div class="message-content">${message}</div>
+            <div class="message-content"></div>
         `;
+        const messageContent = messageElement.querySelector('.message-content');
+        messageContent.textContent = message;
         this.chatMessages.appendChild(messageElement);
         this.scrollChatToBottom();
     }

--- a/banditgui/templates/index.html
+++ b/banditgui/templates/index.html
@@ -40,6 +40,14 @@
                     </div>
                 </div>
                 <div id="chat-input-container">
+                    <div id="ask-a-pro-container" style="display: flex; align-items: center; margin-bottom: 5px;">
+                        <select id="llm-selection-dropdown" style="flex-grow: 1; margin-right: 5px; padding: 8px; border-radius: 4px; border: 1px solid #ccc;">
+                            <!-- Options will be populated by JavaScript -->
+                        </select>
+                        <button id="ask-a-pro-button" class="chat-button" style="padding: 8px 15px; border-radius: 4px; background-color: #4CAF50; color: white; border: none; cursor: pointer;">
+                            <i class="fas fa-user-graduate"></i> Ask-a-Pro
+                        </button>
+                    </div>
                     <input type="text" id="chat-input" placeholder="Chat with the assistant...">
                     <button id="chat-submit"><i class="fas fa-paper-plane"></i></button>
                 </div>

--- a/banditgui/templates/index.html
+++ b/banditgui/templates/index.html
@@ -40,11 +40,11 @@
                     </div>
                 </div>
                 <div id="chat-input-container">
-                    <div id="ask-a-pro-container" style="display: flex; align-items: center; margin-bottom: 5px;">
-                        <select id="llm-selection-dropdown" style="flex-grow: 1; margin-right: 5px; padding: 8px; border-radius: 4px; border: 1px solid #ccc;">
+                    <div id="ask-a-pro-container" class="ask-a-pro-controls">
+                        <select id="llm-selection-dropdown" class="llm-dropdown">
                             <!-- Options will be populated by JavaScript -->
                         </select>
-                        <button id="ask-a-pro-button" class="chat-button" style="padding: 8px 15px; border-radius: 4px; background-color: #4CAF50; color: white; border: none; cursor: pointer;">
+                        <button id="ask-a-pro-button" class="chat-button ask-a-pro-button">
                             <i class="fas fa-user-graduate"></i> Ask-a-Pro
                         </button>
                     </div>

--- a/banditgui/tests/test_app.py
+++ b/banditgui/tests/test_app.py
@@ -40,11 +40,6 @@ def test_hello_world_sanity_check(client):
     # Let's test a known route like /server-status which is GET
     response = client.get('/server-status')
     assert response.status_code == 200 # Assuming server-status is always available and returns 200
-    # This test might fail if /server-status has side effects or dependencies not mocked here.
-    # It's primarily to check if client fixture works.
-    # For now, we'll just check status_code.
-    # A better sanity check would be a dedicated simple health check endpoint if one existed.
-    pass # Will add actual tests next.
 
 # --- Tests for /config/llm_model.json ---
 

--- a/banditgui/tests/test_app.py
+++ b/banditgui/tests/test_app.py
@@ -1,0 +1,286 @@
+import json
+import os
+import pytest
+from banditgui.app import app as flask_app # Renamed to avoid conflict with app fixture
+from unittest.mock import MagicMock # For creating mock objects for litellm response
+
+# Make sure the app is in testing mode
+flask_app.config.update({
+    "TESTING": True,
+})
+
+@pytest.fixture
+def app():
+    """Create and configure a new app instance for each test."""
+    # Ensure the app is in testing mode
+    flask_app.config.update({
+        "TESTING": True,
+    })
+    yield flask_app
+
+@pytest.fixture
+def client(app):
+    """A test client for the app."""
+    return app.test_client()
+
+# Sample data for /ask-a-pro tests
+SAMPLE_ASK_A_PRO_DATA = {
+    "level_name": "0",
+    "level_description": "The goal of this level is to log into the game using SSH.",
+    "command_history": ["ls -la", "whoami"]
+}
+
+# Path to the llm_model.json file
+LLM_MODEL_CONFIG_PATH = os.path.join(os.path.dirname(__file__), '..', 'config', 'llm_model.json')
+
+def test_hello_world_sanity_check(client):
+    """A placeholder test to ensure the test setup is working."""
+    # This is a dummy test. Replace or remove later.
+    # For now, let's assume there isn't a simple '/' route that returns "Hello"
+    # Let's test a known route like /server-status which is GET
+    response = client.get('/server-status')
+    assert response.status_code == 200 # Assuming server-status is always available and returns 200
+    # This test might fail if /server-status has side effects or dependencies not mocked here.
+    # It's primarily to check if client fixture works.
+    # For now, we'll just check status_code.
+    # A better sanity check would be a dedicated simple health check endpoint if one existed.
+    pass # Will add actual tests next.
+
+# --- Tests for /config/llm_model.json ---
+
+def test_serve_llm_model_json_success(client):
+    """Test successful serving of llm_model.json."""
+    # Ensure the llm_model.json file exists for the test to read its content
+    # This assumes it's in banditgui/config/llm_model.json relative to project root
+    # and the test runner is executing from the project root or similar.
+    
+    # Create a dummy llm_model.json in the expected location for the test
+    # The app route serves from 'config' relative to app.root_path (banditgui)
+    config_dir = os.path.join(flask_app.root_path, 'config')
+    os.makedirs(config_dir, exist_ok=True)
+    dummy_llm_json_path = os.path.join(config_dir, 'llm_model.json')
+    
+    expected_content = {"openai": ["gpt-4o"], "ollama": ["test-model"]}
+    with open(dummy_llm_json_path, 'w') as f:
+        json.dump(expected_content, f)
+
+    response = client.get('/config/llm_model.json')
+
+    assert response.status_code == 200
+    assert response.mimetype == 'application/json'
+    
+    actual_data = json.loads(response.data)
+    assert actual_data == expected_content
+    
+    # Clean up the dummy file
+    os.remove(dummy_llm_json_path)
+
+def test_serve_llm_model_json_not_found(client):
+    """Test serving non-existent config file."""
+    response = client.get('/config/other_file.json')
+    assert response.status_code == 404
+    assert response.mimetype == 'application/json' # Flask error handlers often return JSON
+    data = json.loads(response.data)
+    assert data['status'] == 'error'
+    assert "File not found" in data['message']
+
+# --- Tests for /ask-a-pro ---
+
+def test_ask_a_pro_success_openai(client, mocker):
+    """Test successful /ask-a-pro call with OpenAI."""
+    mock_completion = mocker.patch('banditgui.app.completion')
+    mock_getenv = mocker.patch('banditgui.app.os.getenv')
+
+    mock_getenv.side_effect = lambda key: "dummy_openai_key" if key == "OPENAI_API_KEY" else None
+    mock_llm_response = MagicMock()
+    mock_llm_response.choices = [MagicMock()]
+    mock_llm_response.choices[0].message = MagicMock()
+    mock_llm_response.choices[0].message.content = "Mocked LLM advice for OpenAI"
+    mock_completion.return_value = mock_llm_response
+    
+    payload = {
+        "llm": "openai/gpt-4o",
+        **SAMPLE_ASK_A_PRO_DATA
+    }
+    response = client.post('/ask-a-pro', json=payload)
+    data = json.loads(response.data)
+
+    assert response.status_code == 200
+    assert data['status'] == 'success'
+    assert data['advice'] == "Mocked LLM advice for OpenAI"
+
+    mock_getenv.assert_any_call("OPENAI_API_KEY")
+    mock_completion.assert_called_once()
+    args, kwargs = mock_completion.call_args
+    assert kwargs['model'] == "openai/gpt-4o"
+    assert kwargs['api_key'] == "dummy_openai_key"
+    
+    # Check prompt content (simplified check)
+    prompt_arg = kwargs['messages'][0]['content']
+    assert "📍 Level Name: 0" in prompt_arg
+    assert "🧩 Level Description: The goal of this level is to log into the game using SSH." in prompt_arg
+    assert "📜 Command History:" in prompt_arg
+    assert "- ls -la" in prompt_arg
+    assert "- whoami" in prompt_arg
+
+
+def test_ask_a_pro_success_ollama(client, mocker):
+    """Test successful /ask-a-pro call with Ollama."""
+    mock_completion = mocker.patch('banditgui.app.completion')
+    # No need to mock os.getenv for API key for Ollama, but OLLAMA_BASE_URL might be checked by litellm
+    # We assume OLLAMA_BASE_URL is set in the environment or defaults appropriately for litellm.
+    
+    mock_llm_response = MagicMock()
+    mock_llm_response.choices = [MagicMock()]
+    mock_llm_response.choices[0].message = MagicMock()
+    mock_llm_response.choices[0].message.content = "Mocked LLM advice for Ollama"
+    mock_completion.return_value = mock_llm_response
+
+    payload = {
+        "llm": "ollama/qwen2.5-1.5b",
+        **SAMPLE_ASK_A_PRO_DATA
+    }
+    response = client.post('/ask-a-pro', json=payload)
+    data = json.loads(response.data)
+
+    assert response.status_code == 200
+    assert data['status'] == 'success'
+    assert data['advice'] == "Mocked LLM advice for Ollama"
+
+    mock_completion.assert_called_once()
+    args, kwargs = mock_completion.call_args
+    assert kwargs['model'] == "ollama/qwen2.5-1.5b"
+    assert kwargs['api_key'] is None
+
+
+def test_ask_a_pro_api_key_missing(client, mocker):
+    """Test /ask-a-pro when a required API key is missing."""
+    mocker.patch('banditgui.app.completion') # Mock completion to prevent actual call
+    mock_getenv = mocker.patch('banditgui.app.os.getenv')
+    
+    # Simulate COHERE_API_KEY not being set
+    mock_getenv.side_effect = lambda key: None if key == "COHERE_API_KEY" else "some_other_key"
+
+    payload = {
+        "llm": "cohere/command-r-plus", 
+        **SAMPLE_ASK_A_PRO_DATA
+    }
+    response = client.post('/ask-a-pro', json=payload)
+    data = json.loads(response.data)
+
+    assert response.status_code == 500
+    assert data['status'] == 'error'
+    assert "API key for cohere not configured on server" in data['message']
+    mock_getenv.assert_any_call("COHERE_API_KEY")
+
+
+def test_ask_a_pro_litellm_completion_error(client, mocker):
+    """Test /ask-a-pro when litellm.completion raises an error."""
+    mock_completion = mocker.patch('banditgui.app.completion')
+    mock_getenv = mocker.patch('banditgui.app.os.getenv')
+
+    mock_getenv.return_value = "dummy_key" # Generic key for any provider
+    mock_completion.side_effect = Exception("LLM unavailable test error")
+
+    payload = {
+        "llm": "openai/gpt-3.5-turbo", 
+        **SAMPLE_ASK_A_PRO_DATA
+    }
+    response = client.post('/ask-a-pro', json=payload)
+    data = json.loads(response.data)
+
+    assert response.status_code == 500
+    assert data['status'] == 'error'
+    assert "Error calling LLM: LLM unavailable test error" in data['message']
+
+
+def test_ask_a_pro_litellm_not_installed_error(client, mocker):
+    """Test /ask-a-pro when litellm is not installed (NameError)."""
+    # Mock 'completion' to simulate NameError by making it not exist in the module's scope for the test
+    # This is a bit tricky. A direct way is to ensure it's not imported or to mock its absence.
+    # Easier: make it raise NameError.
+    mocker.patch('banditgui.app.os.getenv').return_value = "dummy_key"
+    mocker.patch('banditgui.app.completion', side_effect=NameError("name 'completion' is not defined"))
+
+    payload = {
+        "llm": "openai/gpt-3.5-turbo",
+        **SAMPLE_ASK_A_PRO_DATA
+    }
+    response = client.post('/ask-a-pro', json=payload)
+    data = json.loads(response.data)
+    assert response.status_code == 500
+    assert data['status'] == 'error'
+    assert "LLM integration library (LiteLLM) not available on server" in data['message']
+
+
+def test_ask_a_pro_invalid_input_data(client):
+    """Test /ask-a-pro with missing required input data."""
+    payload = {
+        "llm": "openai/gpt-4o",
+        # Missing level_name, level_description
+        "command_history": ["ls"]
+    }
+    response = client.post('/ask-a-pro', json=payload)
+    data = json.loads(response.data)
+
+    assert response.status_code == 400
+    assert data['status'] == 'error'
+    assert "Missing required data for Ask-a-Pro" in data['message']
+
+def test_ask_a_pro_empty_command_history(client, mocker):
+    """Test /ask-a-pro with empty command history."""
+    mock_completion = mocker.patch('banditgui.app.completion')
+    mock_getenv = mocker.patch('banditgui.app.os.getenv')
+
+    mock_getenv.return_value = "dummy_openai_key"
+    mock_llm_response = MagicMock()
+    mock_llm_response.choices = [MagicMock()]
+    mock_llm_response.choices[0].message = MagicMock()
+    mock_llm_response.choices[0].message.content = "Mocked advice for empty history"
+    mock_completion.return_value = mock_llm_response
+    
+    payload = {
+        "llm": "openai/gpt-4o",
+        "level_name": "1",
+        "level_description": "A different level.",
+        "command_history": [] # Empty history
+    }
+    response = client.post('/ask-a-pro', json=payload)
+    data = json.loads(response.data)
+
+    assert response.status_code == 200
+    assert data['status'] == 'success'
+    assert data['advice'] == "Mocked advice for empty history"
+
+    mock_completion.assert_called_once()
+    args, kwargs = mock_completion.call_args
+    prompt_arg = kwargs['messages'][0]['content']
+    assert "📜 Command History:\nNo commands executed yet." in prompt_arg
+
+def test_ask_a_pro_openrouter_model_name_construction(client, mocker):
+    """Test model name construction for OpenRouter."""
+    mock_completion = mocker.patch('banditgui.app.completion')
+    mock_getenv = mocker.patch('banditgui.app.os.getenv')
+
+    mock_getenv.side_effect = lambda key: "dummy_openrouter_key" if key == "OPENROUTER_API_KEY" else None
+    mock_llm_response = MagicMock()
+    mock_llm_response.choices = [MagicMock()]
+    mock_llm_response.choices[0].message = MagicMock()
+    mock_llm_response.choices[0].message.content = "Mocked LLM advice for OpenRouter"
+    mock_completion.return_value = mock_llm_response
+    
+    payload = {
+        "llm": "openrouter/nous-hermes-2", # from llm_model.json
+        **SAMPLE_ASK_A_PRO_DATA
+    }
+    response = client.post('/ask-a-pro', json=payload)
+    data = json.loads(response.data)
+
+    assert response.status_code == 200
+    assert data['status'] == 'success'
+    
+    mock_completion.assert_called_once()
+    args, kwargs = mock_completion.call_args
+    # The key here is that 'openrouter/' is prepended to the model part from the llm value
+    assert kwargs['model'] == "openrouter/nous-hermes-2" 
+    assert kwargs['api_key'] == "dummy_openrouter_key"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,4 @@
+pytest>=7.0.0
+pytest-mock>=3.0.0
+Flask>=2.0.0 # Already in requirements.txt, but good for test env
+litellm>=1.38.11 # Already in requirements.txt, but good for test env

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ paramiko>=2.7.2
 python-dotenv>=0.19.0
 requests>=2.25.1
 beautifulsoup4>=4.9.3
+litellm>=1.38.11


### PR DESCRIPTION
This commit introduces the "Ask-a-Pro" feature, allowing you to get contextual guidance from an LLM during CTF challenges.

Key changes include:

- **UI Enhancements:**
    - Adds an "Ask-a-Pro" button and an LLM selection dropdown to the chat panel.
    - Populates the dropdown from a new `banditgui/config/llm_model.json` file.
    - Introduces a new "Mentor" message style for LLM responses.

- **Core Logic:**
    - Client-side JavaScript in `bandit-app.js` collects level information (name, description) and command history.
    - A new Flask endpoint `/ask-a-pro` in `app.py` receives this data.
    - The endpoint constructs a detailed prompt based on your context.
    - Integrates with various LLM providers using the `litellm` library.
    - Handles API key management by reading keys from the `.env` file.

- **Configuration:**
    - Adds numerous LLM API key placeholders to `.env.example` and ensures the `.env` file is updated.
    - Creates `banditgui/config/llm_model.json` to list available LLMs for the dropdown.
    - Adds `litellm` to `requirements.txt`.

- **Testing:**
    - Adds comprehensive server-side unit tests for the new `/ask-a-pro` endpoint and the `/config/llm_model.json` route.
    - Tests cover successful calls, error handling, API key logic, prompt generation, and mocked `litellm` interactions.
    - Creates `requirements-dev.txt` for testing dependencies like `pytest` and `pytest-mock`.

The feature prompts the LLM to provide a contextual summary, explanations, learning resources, and suggested actions, without revealing direct solutions, thereby acting as an educational mentor.

## Summary by Sourcery

Implement an interactive LLM-based mentor feature by wiring up UI components, backend logic, configuration, and tests to provide contextual, educational guidance without revealing full solutions.

New Features:
- Add "Ask-a-Pro" mentor feature enabling users to request contextual LLM guidance during CTF challenges
- Introduce chat UI elements including an LLM model selector dropdown, an Ask-a-Pro button, and styled mentor messages
- Implement a Flask `/ask-a-pro` endpoint to assemble level context and forward prompts to multiple LLM providers via litellm

Enhancements:
- Populate dropdown options from `banditgui/config/llm_model.json` and manage provider-specific API keys through environment variables
- Extend client-side logic to capture level descriptions and command history for mentor queries

Build:
- Add `litellm` to `requirements.txt` and create `requirements-dev.txt` for testing dependencies, plus placeholders for various LLM API keys in `.env.example`

Tests:
- Add pytest unit tests for the `/ask-a-pro` endpoint, the config file route, prompt generation, error handling, and mocked litellm interactions