### PR TITLE
feat: Render LLM output as markdown

### DIFF
--- a/banditgui/static/js/bandit-app.js
+++ b/banditgui/static/js/bandit-app.js
@@ -544,7 +544,8 @@ Type <code>level</code> in this chat to see the current level instructions.
             <div class="message-content"></div>
         `;
         const messageContent = messageElement.querySelector('.message-content');
-        messageContent.textContent = message;
+        // Use marked.parse to render Markdown content
+        messageContent.innerHTML = marked.parse(message);
         this.chatMessages.appendChild(messageElement);
         this.scrollChatToBottom();
     }

--- a/banditgui/templates/index.html
+++ b/banditgui/templates/index.html
@@ -11,6 +11,7 @@
         <link rel="stylesheet" href="{{ url_for('static', filename='xterm.css') }}">
         <link rel="stylesheet" href="{{ url_for('static', filename='xterm-custom.css') }}">
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
+        <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
     </head>
     <body>
         <div class="container">

--- a/banditgui/templates/index.html
+++ b/banditgui/templates/index.html
@@ -11,7 +11,7 @@
         <link rel="stylesheet" href="{{ url_for('static', filename='xterm.css') }}">
         <link rel="stylesheet" href="{{ url_for('static', filename='xterm-custom.css') }}">
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
-        <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+        <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js" integrity="sha512-O9dpFitS9XjS30VpLAepQAlZcsYQfoz8IFxSO7yT29XTwn0xVOB0QkQZ0h30Vn2hP2JgqWn7L0xQkE0sZ0p0gA==" crossorigin="anonymous"></script>
     </head>
     <body>
         <div class="container">


### PR DESCRIPTION
This change implements markdown rendering for my messages.

- Included Marked.js library via CDN in `banditgui/templates/index.html`.
- Modified the `addMentorMessage` function in `banditgui/static/js/bandit-app.js` to use `marked.parse()` for converting markdown to HTML before displaying it.

This allows for richer formatting of my responses, improving readability and your experience.

## Summary by Sourcery

Enable markdown support for mentor messages by adding the Marked.js CDN and updating the addMentorMessage function to parse and display markdown content.

New Features:
- Integrate Marked.js to enable markdown rendering for LLM messages
- Update rendering logic to use marked.parse instead of plain text