### PR TITLE
feat: Display LLM interaction in chat for Ask-a-Pro

### DIFF
--- a/banditgui/static/js/bandit-app.js
+++ b/banditgui/static/js/bandit-app.js
@@ -160,7 +160,8 @@ class BanditApp {
                     this.addAssistantMessage("Please make sure you have started a level and its information is displayed before using Ask-a-Pro. Try using the 'level' or 'start' command in the chat.");
                     return;
                 }
-                
+
+                this.addUserMessage(`Asking the Pro about Level ${levelName}: '${levelDescription}' (Command history: ${commandHistory.join(', ') || 'empty'})`);
                 this.addMentorMessage(`Thinking like a Pro with ${selectedLlm.split('/')[1]}...`);
 
 

--- a/banditgui/static/js/bandit-app.js
+++ b/banditgui/static/js/bandit-app.js
@@ -161,7 +161,10 @@ class BanditApp {
                     return;
                 }
 
-                this.addUserMessage(`Asking the Pro about Level ${levelName}: '${levelDescription}' (Command history: ${commandHistory.join(', ') || 'empty'})`);
+                const escapeHTML = (str) => str == null ? '' : String(str).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;").replace(/'/g, "&#039;");
+                const safeLevelDescription = escapeHTML(levelDescription);
+                const safeCommandHistoryString = commandHistory.length > 0 ? commandHistory.map(cmd => escapeHTML(cmd)).join(', ') : 'empty';
+                this.addUserMessage(`Asking the Pro about Level ${levelName}: '${safeLevelDescription}' (Command history: ${safeCommandHistoryString})`);
                 this.addMentorMessage(`Thinking like a Pro with ${selectedLlm.split('/')[1]}...`);
 
 


### PR DESCRIPTION
Modifies the 'Ask-a-Pro' button functionality to display your implicit query to the LLM in the chat interface.

When the 'Ask-a-Pro' button is clicked:
1. A message, styled as your message, is added to the chat. This message details what is being asked, including the current level, its description, and the command history sent to the LLM.
2. The existing 'Thinking like a Pro...' message follows.
3. The LLM's response is then displayed as before.

This change enhances clarity by making the LLM interaction explicit in the chat log.

## Summary by Sourcery

New Features:
- Show the Ask-a-Pro prompt as a user message in the chat, including the level name, description, and command history.